### PR TITLE
Fix hint_c function calculation

### DIFF
--- a/hint.py
+++ b/hint.py
@@ -115,10 +115,10 @@ def hint_d(fcombination: Tuple[int, ...]) -> int:
     return numbers[-1] - numbers[0]
 
 
-def hint_c(fcombination: Tuple[int, ...]) -> bool:
-    """Return a boolean indication if the C tile is strictly greater than 4."""
+def hint_c(fcombination: Tuple[int, ...]) -> str:
+    """Return an indication if the C tile is strictly greater than 4."""
     numbers = cb.fcombination_to_numbers(fcombination)
-    return numbers[2] > 4
+    return 'y' if numbers[2] > 4 else 'n'
 
 
 def _hint_x(fcombination: Tuple[int, ...], x_tile: int) -> str:


### PR DESCRIPTION
**Case:** Enter any combination of tiles, apply hint "(c) Is your C tile greater than 4?"

**ER**: The hint result will be successfully applied and the list of possible combinations will be filtered correctly
**AR**:  As a result of hint application absolutely all possible combinations are deleted regardless of hint answer

![2024-01-10_22-27_1](https://github.com/PhilippeOlivier/break-the-code/assets/38328747/809fa7ed-b712-4cc2-8388-44d46a50623f)
![2024-01-10_22-27](https://github.com/PhilippeOlivier/break-the-code/assets/38328747/187d3018-4e3d-4b47-8f70-102f58e5c8e2)

**Rout cause:** 
The current results of the hint_c function is a bool value when the hint answer value is str:
https://github.com/PhilippeOlivier/break-the-code/blob/master/menu.py#L206

Thus, the result of comparing the result of hint_c function execution for each possible combination and the entered hint answer is always False:
https://github.com/PhilippeOlivier/break-the-code/blob/master/board.py#L46

**Solution:**
The solution to this problem is to change the data type returned by the hint_c function to str ('y' when True, 'n' when False)

![2024-01-10_22-41](https://github.com/PhilippeOlivier/break-the-code/assets/38328747/cd4841cc-c40a-48aa-bea2-463c9da32477)
